### PR TITLE
Replace pandas str operation with list comprehension

### DIFF
--- a/gemlog/gemlog.py
+++ b/gemlog/gemlog.py
@@ -556,8 +556,7 @@ def ReadGem_v0_9_single(filename, offset=0):
         df = pd.read_csv(filename, names=range(13), low_memory=False, skiprows=6)
     except:
         df = pd.read_csv(filename, names=range(13), engine='python', skiprows=6, error_bad_lines = False, warn_bad_lines = False)
-    df['linetype'] = df.iloc[:,0].str[0] # replace this with list comprehension instead
-    #df['linetype'] = df[0].str[0]
+    df['linetype'] = df['linetype'] = [value[0] for value in df[0]]
     df = df.loc[df.loc[:,'linetype'].isin(['D', 'M', 'G']), :]
     #df = df.loc[df['linetype'].isin(['D', 'M', 'G']), :]
     ## most of the runtime is before here

--- a/gemlog/gemlog.py
+++ b/gemlog/gemlog.py
@@ -556,7 +556,7 @@ def ReadGem_v0_9_single(filename, offset=0):
         df = pd.read_csv(filename, names=range(13), low_memory=False, skiprows=6)
     except:
         df = pd.read_csv(filename, names=range(13), engine='python', skiprows=6, error_bad_lines = False, warn_bad_lines = False)
-    df['linetype'] = [value[0] for value in df[0].str[0]
+    df['linetype'] = [value[0] for value in df[0]]
     df = df.loc[df.loc[:,'linetype'].isin(['D', 'M', 'G']), :]
     #df = df.loc[df['linetype'].isin(['D', 'M', 'G']), :]
     ## most of the runtime is before here

--- a/gemlog/gemlog.py
+++ b/gemlog/gemlog.py
@@ -556,7 +556,7 @@ def ReadGem_v0_9_single(filename, offset=0):
         df = pd.read_csv(filename, names=range(13), low_memory=False, skiprows=6)
     except:
         df = pd.read_csv(filename, names=range(13), engine='python', skiprows=6, error_bad_lines = False, warn_bad_lines = False)
-    df['linetype'] = df['linetype'] = [value[0] for value in df[0]]
+    df['linetype'] = [value[0] for value in df[0].str[0]
     df = df.loc[df.loc[:,'linetype'].isin(['D', 'M', 'G']), :]
     #df = df.loc[df['linetype'].isin(['D', 'M', 'G']), :]
     ## most of the runtime is before here


### PR DESCRIPTION
Another speed improvement in the logfile parsing function.  Pandas's handling of string types is not really optimized compared with just normal python, so a list comprehension is actually faster than using the pandas vectorized functions.

Old approach: `df['linetype'] = df[0].str[0]`
```python
In [2]: %time _ = gemlog.ReadGem_v0_9_single('/home/kevin/Downloads/FILE0003.077')
CPU times: user 1.49 s, sys: 162 ms, total: 1.65 s
Wall time: 1.66 s
```

New approach: `df['linetype'] = [value[0] for value in df[0].str[0]`
```python
In [2]: %time _ = gemlog.ReadGem_v0_9_single('/home/kevin/Downloads/FILE0003.077')
CPU times: user 1.17 s, sys: 120 ms, total: 1.29 s
Wall time: 1.29 s
```