### PR TITLE
Update cibuildwheel version; re-enable MacOS x86_64 builds

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-latest, macos-latest]
+        os: [ubuntu-22.04, windows-latest, macos-latest, macos-13]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.1.3
+          python -m pip install cibuildwheel==2.18.1
 
       - name: Build wheels
         run: |


### PR DESCRIPTION
I don't know exactly what changed since November to break the MacOS builds, but I think this PR gets things working again.  It makes two changes:

- Update cibuildwheel, to fix whatever problem `delocate` was having.
- It seems that `macos-latest` advanced to some version that only produces ARM builds, so add `macos-13` to get x86_64 builds as well.

As a side note, the number of linux builds seems a bit excessive to me:

```
20 wheels produced in 7 minutes:
  gemlog-1.7.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl                                  556 kB
  gemlog-1.7.8-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl   539 kB
  gemlog-1.7.8-cp310-cp310-musllinux_1_2_i686.whl                                                          567 kB
  gemlog-1.7.8-cp310-cp310-musllinux_1_2_x86_64.whl                                                        580 kB
  gemlog-1.7.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl                                  594 kB
  gemlog-1.7.8-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl   574 kB
  gemlog-1.7.8-cp311-cp311-musllinux_1_2_i686.whl                                                          600 kB
  gemlog-1.7.8-cp311-cp311-musllinux_1_2_x86_64.whl                                                        617 kB
  gemlog-1.7.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl                                  585 kB
  gemlog-1.7.8-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl   566 kB
  gemlog-1.7.8-cp312-cp312-musllinux_1_2_i686.whl                                                          599 kB
  gemlog-1.7.8-cp312-cp312-musllinux_1_2_x86_64.whl                                                        610 kB
  gemlog-1.7.8-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl                                    564 kB
  gemlog-1.7.8-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl     548 kB
  gemlog-1.7.8-cp38-cp38-musllinux_1_2_i686.whl                                                            576 kB
  gemlog-1.7.8-cp38-cp38-musllinux_1_2_x86_64.whl                                                          592 kB
  gemlog-1.7.8-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl                                    558 kB
  gemlog-1.7.8-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl     541 kB
  gemlog-1.7.8-cp39-cp39-musllinux_1_2_i686.whl                                                            569 kB
  gemlog-1.7.8-cp39-cp39-musllinux_1_2_x86_64.whl                                                          583 kB
```

Could consider dropping the `i686` and `musllinux` builds.  The `win32` builds might be unnecessary at this point too.  Anyway I'll leave that kind of configuration for potential follow-up PRs.